### PR TITLE
Added K8S version 1.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,7 @@ k8s: validate
 .PHONY: 1.14
 1.14:
 	$(MAKE) k8s kubernetes_version=1.14.6 kubernetes_build_date=2019-08-22
+	
+.PHONY: 1.15
+1.15:
+	$(MAKE) k8s kubernetes_version=1.15.10 kubernetes_build_date=2020-02-22


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added Kubernetes version 1.15 in the Make file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
